### PR TITLE
Add bulk-schedule script

### DIFF
--- a/schedule_scans_for_all_targets.py
+++ b/schedule_scans_for_all_targets.py
@@ -1,31 +1,31 @@
 #!/usr/bin/env python
 
-import csv
-import requests
-from urllib.parse import urljoin
+"""
+Find all targets with zero or one scheduled scans
+and update them all to run at the same time (roughly)
+"""
 
 from datetime import datetime
 from datetime import timedelta
+from urllib.parse import urljoin
+import requests
 
 API_BASE_URL = "https://api.probely.com"
 
 def api_headers(api_token):
-    return {"Authorization": "JWT {}".format(api_token)}
-
-# def flatten_scan_response(scheduled_scan):
-#     return {
-#         "id": scheduled_scan["id"],
-#         "target_id": scheduled_scan["target"]["id"],
-#         "target_name": scheduled_scan["target"]["site"]["name"]
-#     }
+    """Get the appropriate API headers for Probely"""
+    return {"Authorization": f"JWT {api_token}"}
 
 def target_schedules(api_token):
+    """Get a list of all the scheduled scans, grouped by target"""
     scheduled_scans_endpoint = urljoin(
         API_BASE_URL, "scheduledscans/?length=10000"
     )
 
-    headers = api_headers(api_token)
-    response = requests.get(scheduled_scans_endpoint, headers=headers)
+    response = requests.get(scheduled_scans_endpoint,
+                            headers=api_headers(api_token),
+                            timeout=10)
+
     # print(response.content)
     # results = list(map(flatten_scan_response, response.json()["results"]))
 
@@ -44,139 +44,92 @@ def target_schedules(api_token):
             "next_scan": scheduled_scan["date_time"],
             "recurrence": scheduled_scan["recurrence"],
         })
-           
     return targets
 
 def main():
+    """
+    Find and update all targets with one or fewer scheduled scans to use
+    a new schedule, stepping targets to prevent heavy load across our estate
+    """
+
     api_token = input("API Token:")
-    
     targets = target_schedules(api_token=api_token)
 
-    # update the schedules for all the targets
-    #
+    # Get targets with no schedule
+    targets_endpoint = urljoin(
+        API_BASE_URL, "targets/?include=compliance&length=10000"
+    )
+
+    response = requests.get(targets_endpoint,
+                            headers=api_headers(api_token=api_token),
+                            timeout=10)
+
+    results = response.json()["results"]
+
+    for target in results:
+        target_id = target["id"]
+        if target_id not in targets:
+            targets[target_id] = {
+                "id": target_id,
+                "name": target["site"]["name"],
+                "scheduled_scans": []
+            }
 
     # Given timestamp in string
-    time_str = '23/9/2023 00:00:00'
-    date_format_str = '%d/%m/%Y %H:%M:%S'
+    time_str = '14/10/2023 00:00:00'
 
     # create datetime object from timestamp string
-    start_time = datetime.strptime(time_str, date_format_str)
-    minutes_to_add_each_time = 5
+    start_time = datetime.strptime(time_str, '%d/%m/%Y %H:%M:%S')
 
     for target_id, target in targets.items():
         target_name = target["name"]
 
-        start_time = start_time + timedelta(minutes=minutes_to_add_each_time)
+        start_time = start_time + timedelta(minutes=2)
 
-        # Convert datetime object to string in the format Probely needs 
-        schedule_time_str = start_time.strftime('%Y-%m-%dT%H:%M:%SZ')
-
-        # Create a payload to create a scheduled scan. 
-        # See https://developers.probely.com/#tag/Scheduled-Scans/operation/targets_scheduledscans_create
+        # Create a payload to create a scheduled scan.
+        # See https://developers.probely.com
         schedule_payload = {
-            "date_time": schedule_time_str,
+            "date_time": start_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
             "recurrence": "w", # weekly
             "timezone": "UTC",
         }
 
-        target_id = target["id"]
-        
         schedule_count = len(target["scheduled_scans"])
-        
+
         if schedule_count > 1:
             print(f"ERROR: multiple scheduled scans found for target '{target_name}'")
         elif schedule_count == 1:
             old_schedule = target["scheduled_scans"][0]["next_scan"]
             old_recurrence = target["scheduled_scans"][0]["recurrence"]
-            print(f"Updating schedule for {target_name} from {old_schedule} ({old_recurrence}) to {schedule_payload}")
-            scheduled_scan_id = target["scheduled_scans"][0]["id"]
-            scheduled_scan_put_url = urljoin(API_BASE_URL, f"targets/{target_id}/scheduledscans/{scheduled_scan_id}")
+            print(f"Updating schedule for {target_name} from {old_schedule} ({old_recurrence}) to {schedule_payload}") # pylint: disable=line-too-long
 
-            # response = requests.put(
-            #     scheduled_scan_url,
-            #     headers=headers,
-            #     json=schedule_payload,
-            # )
+            scheduled_scan_put_url = urljoin(
+                API_BASE_URL,
+                f'targets/{target_id}/scheduledscans/{target["scheduled_scans"][0]["id"]}')
 
-            # print(response.status_code)
-            # print(response.reason)
-            # print(response.content)
+            response = requests.patch(
+                scheduled_scan_put_url,
+                headers=api_headers(api_token=api_token),
+                json=schedule_payload,
+                timeout=10
+            )
+
+            print(response.status_code)
+            print(response.reason)
+            print(response.content)
         else:
             print(f"Creating schedule for {target_name}: {schedule_payload}")
-            scheduled_scan_post_url = urljoin(API_BASE_URL, f"targets/{target_id}/scheduledscans/")
 
-            # response = requests.patch(
-            #     scheduled_scan_url,
-            #     headers=headers,
-            #     json=schedule_payload,
-            # )
+            response = requests.post(
+                urljoin(API_BASE_URL, f"targets/{target_id}/scheduledscans/"),
+                headers=api_headers(api_token=api_token),
+                json=schedule_payload,
+                timeout=10
+            )
 
-            # print(response.status_code)
-            # print(response.reason)
-            # print(response.content)
-        
-    quit()
-
-    # targets_endpoint = urljoin(
-    #     API_BASE_URL, "targets/?include=compliance&length=10000"
-    # )
-    # headers = api_headers(api_token)
-    # response = requests.get(targets_endpoint, headers=headers)
-    # results = response.json()["results"]
-
-        # target id
-        # "date_time": "2019-08-24T14:15:22Z",
-        # "recurrence": "h",
-        # "timezone": "string",
-        # "run_on_day_of_week": true,
-        # "scheduled_day_of_week": 1,
-        # "week_index": "first",
-        # "partial_scan": true,
-        # "override_target_settings": true,
-        # "incremental": true,
-        # "reduced_scope": true,
-        # "scan_profile": "lightning"
-
-    # # Given timestamp in string
-    # time_str = '23/9/2023 00:00:00'
-    # date_format_str = '%d/%m/%Y %H:%M:%S'
-
-    # # create datetime object from timestamp string
-    # start_time = datetime.strptime(time_str, date_format_str)
-    # minutes_to_add_each_time = 5
-
-    # for result in results:
-    #     start_time = start_time + timedelta(minutes=minutes_to_add_each_time)
-
-    #     # Convert datetime object to string in the format Probely needs 
-    #     schedule_time_str = start_time.strftime('%Y-%m-%dT%H:%M:%SZ')
-
-    #     # Create a payload to create a scheduled scan. 
-    #     # See https://developers.probely.com/#tag/Scheduled-Scans/operation/targets_scheduledscans_create
-    #     schedule_payload = {
-    #         "date_time": schedule_time_str,
-    #         "recurrence": "w", # weekly
-    #         "timezone": "UTC",
-    #     }
-
-    #     target_id = result["id"]
-    #     scheduled_scan_url = urljoin(
-    #         API_BASE_URL, f"targets/{target_id}/scheduledscans/"
-    #     )
-
-        # Send the new scheduled scan to Probely
-        # response = requests.post(
-        #     scheduled_scan_url,
-        #     headers=headers,
-        #     json=schedule_payload,
-        # )
-
-        # print(scheduled_scan_url)
-        # print(schedule_payload)
-        # print(response.status_code)
-        # print(response.reason)
-        # print(response.content)
-
+            print(response.status_code)
+            print(response.reason)
+            print(response.content)
 
 if __name__ == '__main__':
     main()

--- a/schedule_scans_for_all_targets.py
+++ b/schedule_scans_for_all_targets.py
@@ -7,16 +7,53 @@ from urllib.parse import urljoin
 from datetime import datetime
 from datetime import timedelta
 
-def main():
-    token = input("API Token:")
+API_BASE_URL = "https://api.probely.com"
 
-    headers = {"Authorization": "JWT {}".format(token)}
+def api_headers(api_token):
+    return {"Authorization": "JWT {}".format(api_token)}
 
-    api_base_url = "https://api.probely.com"
-    targets_endpoint = urljoin(
-        api_base_url, "targets/?include=compliance&length=10000"
+# def flatten_scan_response(scheduled_scan):
+#     return {
+#         "id": scheduled_scan["id"],
+#         "target_id": scheduled_scan["target"]["id"],
+#         "target_name": scheduled_scan["target"]["site"]["name"]
+#     }
+
+def get_scheduled_scans(api_token):
+    scheduled_scans_endpoint = urljoin(
+        API_BASE_URL, "scheduledscans/?length=10000"
     )
 
+    headers = api_headers(api_token)
+    response = requests.get(scheduled_scans_endpoint, headers=headers)
+    print(response.content)
+    # results = list(map(flatten_scan_response, response.json()["results"]))
+
+    targets = {}
+    for scheduled_scan in response.json()["results"]:
+        target_id = scheduled_scan["target"]["id"]
+        if target_id not in targets:
+            targets[target_id] = {
+                "id": target_id,
+                "name": scheduled_scan["target"]["site"]["name"],
+                "scheduled_scans": []
+            }
+
+        targets[target_id]["schedule_scans"].append({
+            scheduled_scan["id"]
+        })
+    print(results)
+
+def main():
+    api_token = input("API Token:")
+    
+    get_scheduled_scans(api_token=api_token)
+    quit()
+
+    targets_endpoint = urljoin(
+        API_BASE_URL, "targets/?include=compliance&length=10000"
+    )
+    headers = api_headers(api_token)
     response = requests.get(targets_endpoint, headers=headers)
     results = response.json()["results"]
 
@@ -65,15 +102,15 @@ def main():
 
         target_id = result["id"]
         scheduled_scan_url = urljoin(
-            api_base_url, f"targets/{target_id}/scheduledscans/"
+            API_BASE_URL, f"targets/{target_id}/scheduledscans/"
         )
 
         # Send the new scheduled scan to Probely
-        response = requests.post(
-            scheduled_scan_url,
-            headers=headers,
-            json=schedule_payload,
-        )
+        # response = requests.post(
+        #     scheduled_scan_url,
+        #     headers=headers,
+        #     json=schedule_payload,
+        # )
 
         # print(scheduled_scan_url)
         print(schedule_payload)

--- a/schedule_scans_for_all_targets.py
+++ b/schedule_scans_for_all_targets.py
@@ -26,7 +26,7 @@ def get_scheduled_scans(api_token):
 
     headers = api_headers(api_token)
     response = requests.get(scheduled_scans_endpoint, headers=headers)
-    print(response.content)
+    # print(response.content)
     # results = list(map(flatten_scan_response, response.json()["results"]))
 
     targets = {}
@@ -39,10 +39,10 @@ def get_scheduled_scans(api_token):
                 "scheduled_scans": []
             }
 
-        targets[target_id]["schedule_scans"].append({
+        targets[target_id]["scheduled_scans"].append({
             scheduled_scan["id"]
         })
-    print(results)
+    # print(results)
 
 def main():
     api_token = input("API Token:")
@@ -113,9 +113,9 @@ def main():
         # )
 
         # print(scheduled_scan_url)
-        print(schedule_payload)
-        print(response.status_code)
-        print(response.reason)
+        # print(schedule_payload)
+        # print(response.status_code)
+        # print(response.reason)
         # print(response.content)
 
 

--- a/schedule_scans_for_all_targets.py
+++ b/schedule_scans_for_all_targets.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+import csv
+import requests
+from urllib.parse import urljoin
+
+from datetime import datetime
+from datetime import timedelta
+
+def main():
+    token = input("API Token:")
+
+    headers = {"Authorization": "JWT {}".format(token)}
+
+    api_base_url = "https://api.probely.com"
+    targets_endpoint = urljoin(
+        api_base_url, "targets/?include=compliance&length=10000"
+    )
+
+    response = requests.get(targets_endpoint, headers=headers)
+    results = response.json()["results"]
+
+        # target id
+        # "date_time": "2019-08-24T14:15:22Z",
+        # "recurrence": "h",
+        # "timezone": "string",
+        # "run_on_day_of_week": true,
+        # "scheduled_day_of_week": 1,
+        # "week_index": "first",
+        # "partial_scan": true,
+        # "override_target_settings": true,
+        # "incremental": true,
+        # "reduced_scope": true,
+        # "scan_profile": "lightning"
+
+    # Given timestamp in string
+    time_str = '23/9/2023 00:00:00'
+    date_format_str = '%d/%m/%Y %H:%M:%S'
+
+    # create datetime object from timestamp string
+    start_time = datetime.strptime(time_str, date_format_str)
+    minutes_to_add_each_time = 5
+
+    for result in results:
+        start_time = start_time + timedelta(minutes=minutes_to_add_each_time)
+
+        # Convert datetime object to string in the format Probely needs 
+        schedule_time_str = start_time.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        # Create a payload to create a scheduled scan. 
+        # See https://developers.probely.com/#tag/Scheduled-Scans/operation/targets_scheduledscans_create
+        schedule_payload = {
+            "date_time": schedule_time_str,
+            "recurrence": "w", # weekly
+            "timezone": "UTC",
+            # "run_on_day_of_week":
+            # "scheduled_day_of_week": 6, # Saturday
+            # "week_index":
+            # "partial_scan": False
+            # "override_target_settings":
+            # "incremental":
+            # "reduced_scope":
+            # "scan_profile": # not set, as we'll use the target's settings
+        }
+
+        target_id = result["id"]
+        scheduled_scan_url = urljoin(
+            api_base_url, f"targets/{target_id}/scheduledscans/"
+        )
+
+        # Send the new scheduled scan to Probely
+        response = requests.post(
+            scheduled_scan_url,
+            headers=headers,
+            json=schedule_payload,
+        )
+
+        # print(scheduled_scan_url)
+        print(schedule_payload)
+        print(response.status_code)
+        print(response.reason)
+        # print(response.content)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
We've added a bulk-schedule script which updates all the targets with one or zero scheduled scans, so we can add new targets and space the scans so we don't accidentally DoS our estate.